### PR TITLE
re-train with unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 pythonenv*/
 __pycache__/
 test/data/
+test/retrain_data/
 src/tests/performance_rf.txt
+.vscode

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Parameters:
 - **evaluation_split_point**: define training and testing spliting point in the dataset, for model evaluation during learning phase (fit takes twice as long time)
 - **prediction_horizons**: list of prediction horizons (in hours) for which the model will be trained to predict for.
 - **sesnors**: list of sensors for which this specific instance will train the models and will be making predictions.
+- **retrain_period**: A number of recieved samples after which the model will be re-trained. This is an optional parameter. If it is not specified no re-training will be done.
+- **samples_for_retrain**: A number of samples that will be used for re-training. If retrain_period is not specified this parameter will be ignored. This is an optional parameter. If it is not specified (and retrain_period is) the re-train will be done on all samples recieved since the component was started.
 
 Example of config file:
 ```json
@@ -38,7 +40,9 @@ Example of config file:
     "evaluation_period": 72,
     "evaluation_split_point": 0.8,
     "prediction_horizons": [1, 2, 3],
-    "sensors": ["test", "test2"]
+    "sensors": ["test", "test2"],
+    "retrain_period": 100,
+    "samples_for_retrain": 5000
 }
 ```
 
@@ -63,6 +67,7 @@ Alternetively, process managers like `PM2` or `pman` would be a better fit for t
 
 ## Assumptions:
 - **Training data**: all the training files should be stored in a subfolder called `/data/fused`. Data should be stored as json objects per line (e.g. `{ "timestamp": 1459926000, "ftr_vector": [1, 2, 3]}`). Separate file for each sensor and prediction horizon. Files should be named the same as input kafka topics, that is `{sensor}_{horizon}h` (e.g. `sensor1_3h.json`)
+- **Re-training data**: all the re-training data (if re-training is specified) will be stored in a subfolder called `/data/retrain_data` in the same form as training data. Seperate files will be made for each sensor and prediction horizon. The names of the files will  be in the following form: `{sensor}_{horizon}h_retrain.json` (eg. `sensor1_3h_retrain.json`).
 - **Models**: all the models are stored in a subfolder called `/models`.  Each sensor and horizon has its own model. The name of the models is composed of sensor name and prediction horizon, `model_{sensor}_{horizon}h` (e.g. `model_sensor1_3h`)
 - **Input kafka topic**: The names of input kafka topics on which the prototype is listening for live data should be in the same format as trainng data file names, that is `features_{sensor}_{horizon}h`.
 - **Output kafka topic**: Predictions are sent on different topics based on a sensor names, that is `{sensor}` (e.g. `sensor1`).

--- a/src/main.py
+++ b/src/main.py
@@ -143,10 +143,28 @@ def main():
         {'name': "Mean Absolute Percentage Error", 'short': "mape", 'function': additional_metrics.mean_absolute_percentage_error}
     ]
 
+    # Ifretrain period is defined read it from conf otherwise use None
+    if("retrain_period" in conf):
+        retrain_period = conf["retrain_period"]
+        if("samples_for_retrain" in conf):
+            samples_for_retrain = conf["samples_for_retrain"]
+        else:
+            samples_for_retrain = None
+    else:
+        retrain_period = None
+        samples_for_retrain = None
+
     for sensor in sensors:
         models[sensor] = {}
         for horizon in horizons:
-            models[sensor][horizon] = PredictiveModel(algorithm, sensor, horizon, evaluation_period, error_metrics, evaluation_split_point)
+            models[sensor][horizon] = PredictiveModel(algorithm, sensor,
+                                                      horizon,
+                                                      evaluation_period,
+                                                      error_metrics,
+                                                      evaluation_split_point,
+                                                      retrain_period,
+                                                      samples_for_retrain,
+                                                      os.path.join('.', 'test', 'retrain_data'))
             print("Initializing model_{}_{}h".format(sensor, horizon))
 
     # Model learning
@@ -219,7 +237,7 @@ def main():
 
                 # predictions
                 model = models[sensor][horizon]
-                predictions = model.predict([ftr_vector])
+                predictions = model.predict([ftr_vector], timestamp)
 
                 # output record
                 output = {'stampm': timestamp,


### PR DESCRIPTION
Re-train was implemented and after every prediction call the sample is saved into file which is then used for re-train. Timestamp argument was added to predict function so it can be saved into the file with feature vector. Parameters retrain_period and samples_for_retrain were added to config file (explained in READEME.md). 3 unit tests were made to test the re-train functionality.